### PR TITLE
improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /log/*
 !/log/.keep
 /tmp
+
+young-stream*


### PR DESCRIPTION
we had these annoying `young-stream` thingies from heroku that (I think) we don't want to commit. This is how you avoid tracking them with git.
